### PR TITLE
Fix make minimap2 options if ARM detected

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,6 +5,15 @@ GZSTREAM_DIR = $(EXT_DIR)/gzstream
 LIBGZSTREAM_A = $(GZSTREAM_DIR)/libgzstream.a
 LIBMINIMAP2_A = $(MINIMAP2_DIR)/libminimap2.a
 
+UNAME_P := $(shell uname -p)
+MINIMAP2_OPT =
+ifneq ($(filter arm%,$(UNAME_P)),)
+	MINIMAP2_OPT = arm_neon=1 aarch64=1
+endif
+ifneq ($(filter aarch%,$(UNAME_P)),)
+	MINIMAP2_OPT = arm_neon=1 aarch64=1
+endif
+
 readItAndKeep: $(LIBMINIMAP2_A) $(LIBGZSTREAM_A)
 	g++ -std=c++11 -Wall -O2 -I$(MINIMAP2_DIR)/ -I$(GZSTREAM_DIR)  -pthread -O2 readItAndKeep.cpp $(LIBMINIMAP2_A) $(LIBGZSTREAM_A) -lz -lm -o readItAndKeep
 
@@ -12,7 +21,7 @@ $(LIBGZSTREAM_A) :
 	$(MAKE) -C $(GZSTREAM_DIR)
 
 $(LIBMINIMAP2_A) :
-	$(MAKE) -C $(MINIMAP2_DIR)
+	$(MAKE) -C $(MINIMAP2_DIR) $(MINIMAP2_OPT)
 
 clean:
 	$(RM) readItAndKeep


### PR DESCRIPTION
Detect if architecture is ARM and then use minimap2 make options that work. Tested on M1 mac and in ubuntu VM on M1 Mac.