### PR TITLE
Fix github urls (genome -> global)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,6 +124,11 @@ jobs:
     - name: Check out code for the build
       uses: actions/checkout@v2
 
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
     - name: Install dependencies
       run: |
         pip3 install pytest pyfastaq

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ sudo singularity build readItAndKeep.sif Singularity.def
 
 If you are using `readItAndKeep` for SARS-CoV-2 reads, then we recommend that
 you use the reference genome MN908947.3, but with the poly-A tail removed.
-This is explained in the preprint
-https://www.biorxiv.org/content/10.1101/2022.01.21.477194v1.
+This is explained in the publication
+https://doi.org/10.1093/bioinformatics/btac311.
 A FASTA file of MN908947.3 without the poly-A tail is available in
 this repository: `tests/MN908947.3.no_poly_A.fa`.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ conda activate read-it-and-keep
 
 Get a Docker container of the latest release:
 ```
-docker pull ghcr.io/genomepathogenanalysisservice/read-it-and-keep:latest
+docker pull ghcr.io/globalpathogenanalysisservice/read-it-and-keep:latest
 ```
 
 Alternatively, build a docker container by cloning this repository and running:
@@ -37,7 +37,7 @@ docker build -f Dockerfile -t <TAG> .
 ```
 
 ### Singularity
-[Releases](https://github.com/GenomePathogenAnalysisService/read-it-and-keep/releases)
+[Releases](https://github.com/GlobalPathogenAnalysisService/read-it-and-keep/releases)
 include a Singularity image to download, called
 `readItAndKeep_vX.Y.Z.img`, where X.Y.Z is the release version.
 
@@ -134,6 +134,6 @@ make test
 ## Acknowledgements
 
 This repository includes unedited copies of the code from:
-* [gzstream](https://www.cs.unc.edu/Research/compgeom/gzstream/), [LGPL 2.1 licence](https://github.com/GenomePathogenAnalysisService/read-it-and-keep/blob/main/src/ext/gzstream/COPYING.LIB)
-* [minimap2](https://github.com/lh3/minimap2), [MIT licence](https://github.com/GenomePathogenAnalysisService/read-it-and-keep/blob/main/src/ext/minimap2-2.22/LICENSE.txt)
-* [CLI11](https://github.com/CLIUtils/CLI11) header file, licence is at start of [cli11.hpp](https://github.com/GenomePathogenAnalysisService/read-it-and-keep/blob/main/src/CLI11.hpp)
+* [gzstream](https://www.cs.unc.edu/Research/compgeom/gzstream/), [LGPL 2.1 licence](https://github.com/GlobalPathogenAnalysisService/read-it-and-keep/blob/main/src/ext/gzstream/COPYING.LIB)
+* [minimap2](https://github.com/lh3/minimap2), [MIT licence](https://github.com/GlobalPathogenAnalysisService/read-it-and-keep/blob/main/src/ext/minimap2-2.22/LICENSE.txt)
+* [CLI11](https://github.com/CLIUtils/CLI11) header file, licence is at start of [cli11.hpp](https://github.com/GlobalPathogenAnalysisService/read-it-and-keep/blob/main/src/CLI11.hpp)


### PR DESCRIPTION
Fix urls: replace "GenomePathogenAnalysisService" with "GlobalPathogenAnalysisService"

See issue #15 - solves the docker pull problem, but not the ART 404 problem.