### PR TITLE
Use ubuntu-latest instead of 20.04

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   build:
     name: Build linux/singularity
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - name: Set up Go 1.16

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,7 +118,7 @@ jobs:
 
   mac_build:
     name: Build mac os
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
 
     - name: Check out code for the build


### PR DESCRIPTION
Github actions is dropping support for ubuntu 20.04 on 2025-04-01. Use `ubuntu-latest` to build, instead of `ubuntu-20.04`